### PR TITLE
Remove shapely dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -29,7 +29,6 @@ requirements:
     - traittypes >=0.2.1,<0.3.0
     - xyzservices >=2021.8.1
     - branca >=0.3.1,<0.5.0
-    - shapely
 
 test:
   imports:


### PR DESCRIPTION
Shapely is a soft dependency since 0.14